### PR TITLE
Fallback fix

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -88,10 +88,15 @@
     },
     "clock": {
       "Package": "clock",
-      "Version": "0.4.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "087c01a8f02b109e8a568112ec4b01d0"
+      "Version": "0.5.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "r-lib",
+      "RemoteRepo": "clock",
+      "RemoteRef": "main",
+      "RemoteSha": "c22b1dfa41ab32dfbdd98001955872bf96b14375",
+      "Hash": "134704703d0b429b74d366fbc7f7cf74"
     },
     "config": {
       "Package": "config",
@@ -102,10 +107,10 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.3.1",
+      "Version": "0.4.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "e02edab2bc389c5e4b12949b13df44f2"
+      "Hash": "70976176dfd7f179f212783aab2547b1"
     },
     "crayon": {
       "Package": "crayon",
@@ -155,6 +160,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+    },
+    "evaluate": {
+      "Package": "evaluate",
+      "Version": "0.14",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
     },
     "fansi": {
       "Package": "fansi",
@@ -212,12 +224,26 @@
       "Repository": "RSPM",
       "Hash": "24b224366f9c2e7534d2344d10d59211"
     },
+    "highr": {
+      "Package": "highr",
+      "Version": "0.9",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4"
+    },
     "hms": {
       "Package": "hms",
       "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "e4bf161ccb74a2c1c0e8ac63bbe332b4"
+    },
+    "htmltools": {
+      "Package": "htmltools",
+      "Version": "0.5.1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "af2c2531e55df5cf230c4b5444fc973c"
     },
     "httpgd": {
       "Package": "httpgd",
@@ -252,6 +278,13 @@
       "Repository": "RSPM",
       "Hash": "98138e0994d41508c7a6b84a0600cfcb"
     },
+    "knitr": {
+      "Package": "knitr",
+      "Version": "1.33",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "0bc1b5da1b0eb07cd4b727e95e9ff0b8"
+    },
     "later": {
       "Package": "later",
       "Version": "1.2.0",
@@ -279,6 +312,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "41287f1ac7d28a92f0a286ed507928d3"
+    },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
     },
     "mime": {
       "Package": "mime",
@@ -357,6 +397,13 @@
       "Repository": "RSPM",
       "Hash": "515f341d3affe0de9e4a7f762efb0456"
     },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.10",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "1fb097f233ee98968f8e5d0bcd42df6d"
+    },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.0.2",
@@ -420,6 +467,13 @@
       "Repository": "RSPM",
       "Hash": "7243004a708d06d4716717fa1ff5b2fe"
     },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.33",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "6e0ad90ac5669e35d5456cb61b295acb"
+    },
     "twitchr": {
       "Package": "twitchr",
       "Version": "0.1.0",
@@ -434,10 +488,10 @@
     },
     "tzdb": {
       "Package": "tzdb",
-      "Version": "0.1.2",
+      "Version": "0.2.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "fb2b801053decce71295bb8cb04d438b"
+      "Hash": "5e069fb033daf2317bd628d3100b75c5"
     },
     "usethis": {
       "Package": "usethis",
@@ -480,6 +534,13 @@
       "Source": "Repository",
       "Repository": "RSPM",
       "Hash": "ad03909b44677f930fa156d47d7a3aeb"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.25",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "853d45ffff0a9af1e0af017cd359f75e"
     },
     "xml2": {
       "Package": "xml2",

--- a/utils.R
+++ b/utils.R
@@ -54,7 +54,7 @@ shift_week <- function(x, convert = TRUE, which = "next") {
   } else {
     # get current day of week from supplied date
     x_weekday <- clock::as_year_month_weekday(x) %>% clock::get_day()
-    res <- clock::date_shift(x, target = clock::weekday(x_weekday), which = which, boundary = "advance")
+    res <- clock::date_shift(x, target = clock::weekday(x_weekday), which = which, boundary = "advance", ambiguous = "earliest")
     return(res)
   }
 }


### PR DESCRIPTION
The recent time change (fallback) in 2021 resulted in a particularly gnarly edge case. For streams that occurred on November 14, 2021 at 1 AM, the `shift_week` function I created (wrapping the `clock::date_shift()` function) would crash because it could not determine what the previous week's date should be. With an update to the latest GitHub version of `{clock}` we can now supply an `ambiguous = 'earliest'` parameter in the date shift function to resolve it.  I'll be honest that it still does not make complete sense, but the docs at https://clock.r-lib.org/articles/articles/motivations.html#ambiguous-time-1 give more details.